### PR TITLE
Check babel version and warn if prerequisites are not met

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
+var semver = require('semver');
+
 module.exports = function(precompile) {
   return function(babel) {
+    if (!semver.satisfies(babel.version, '>= 5.2.10')) {
+      throw new Error("htmlbars-inline-precompile requires at least babel v5.2.10");
+    }
+
     var t = babel.types;
 
     return new babel.Transformer('htmlbars-inline-precompile', {

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "babel-core": "^5.2.10",
     "mocha": "^2.2.4"
+  },
+  "dependencies": {
+    "semver": "^4.3.4"
   }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -58,4 +58,10 @@ describe("htmlbars-inline-precompile", function() {
       transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs`string ${value}`");
     }, /placeholders inside a tagged template string are not supported/);
   });
+
+  it("throws an error when an incompatible version of babel is used", function() {
+    assert.throws(function() {
+      HTMLBarsInlinePrecompile()({ version: "5.2.9" });
+    }, "htmlbars-inline-precompile requires at least babel v5.2.10");
+  });
 });


### PR DESCRIPTION
Support for replacing nodes with a source string has been added https://github.com/babel/babel/commit/0fc02f2cf09e0b1fe8738646c815b869921863b9 (available since `v5.2.7`). Due a [bug](https://github.com/babel/babel/commit/92dd67856e5c5f94f0a7fa24f55ab7e516704b42) at least `v5.2.10` is required.

An assertion checking `babel.version >= 5.2.10` should be added to warn if the requirement isn't met.