### PR TITLE
Replace remove() with dangerouslyRemove()

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,15 @@ module.exports = function(precompile) {
             throw file.errorWithNode(node, msg);
           }
 
-          this.remove();
+          // Prefer calling dangerouslyRemove instead of remove (if present) to
+          // suppress a deprecation warning.
+          //
+          // TODO: delete the fallback once we only support babel >= 5.5.0.
+          if (typeof this.dangerouslyRemove === 'function') {
+            this.dangerouslyRemove();
+          } else {
+            this.remove();
+          }
         }
       },
 


### PR DESCRIPTION
Fixes this deprecation warning from babel-core which appears on build:

> Trace: Path#remove has been renamed to Path#dangerouslyRemove,
> removing a node is extremely dangerous so please refrain using it.

I think that in this case it's not dangerous, because the module being imported doesn't actually exist.

Thanks for ember-cli-htmlbars-inline-precompile, we're using it a ton and it's really useful :heart: 