### PR TITLE
Use `path.replaceWithSourceString` to avoid deprecation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,17 @@ module.exports = function(precompile) {
             return quasi.value.cooked;
           }).join("");
 
-          return "Ember.HTMLBars.template(" + precompile(template) + ")";
+          var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template) + ")";
+          
+          // Prefer calling replaceWithStringSource if it is present.
+          // this prevents a deprecation warning in Babel 5.6.7+.
+          // 
+          // TODO: delete the fallback once we only support babel >= 5.6.7.
+          if (this.replaceWithStringSource) {
+            this.replaceWithStringSource(compiledTemplateString);
+          } else {
+            return compiledTemplateString;
+          }
         }
       }
     });


### PR DESCRIPTION
Prevent deprecation warning on Babel 5.6.7+. 

---

Full disclosure: I edited this file on GH and have not tested this change :four_leaf_clover: