### PR TITLE
Allow single string as argument for hbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ test("inline templates ftw", function(assert) {
 });
 ```
 
+If the template is compact, a normal string can be passed as argument as well:
+
+``` js
+import hbs from 'htmlbars-inline-precompile';
+
+module("my view");
+
+test("inline templates ftw", function(assert) {
+  var view = Ember.View.create({
+    greeting: "inline template world",
+    template: hbs('<h1>{{view.greeting}}</h1>')
+  });
+
+  view.appendTo('#testing');
+
+  assert.equal(view.$().html().trim(), "<h1>inline template world</h1>");
+});
+```
+
+
 ## Usage
 
 ``` js

--- a/index.js
+++ b/index.js
@@ -42,6 +42,22 @@ module.exports = function(precompile) {
         }
       },
 
+      CallExpression: function(node, parent, scope, file) {
+        if (t.isIdentifier(node.callee, { name: file.importSpecifier })) {
+          var argumentErrorMsg = "hbs should be invoked with a single argument: the template string";
+          if (node.arguments.length !== 1) {
+            throw file.errorWithNode(node, argumentErrorMsg);
+          }
+
+          var template = node.arguments[0].value;
+          if (typeof template !== "string") {
+            throw file.errorWithNode(node, argumentErrorMsg);
+          }
+
+          return replaceNodeWithPrecompiledTemplate(this, template);
+        }
+      },
+
       TaggedTemplateExpression: function(node, parent, scope, file) {
         if (t.isIdentifier(node.tag, { name: file.importSpecifier })) {
           if (node.quasi.expressions.length) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -58,4 +58,32 @@ describe("htmlbars-inline-precompile", function() {
       transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs`string ${value}`");
     }, /placeholders inside a tagged template string are not supported/);
   });
+
+  describe('single string argument', function() {
+    it("works with a plain string as parameter hbs('string')", function() {
+      var transformed = transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs('hello');", function(template) {
+        return "precompiled(" + template + ")";
+      });
+
+      assert.equal(transformed, "var compiled = Ember.HTMLBars.template(precompiled(hello));", "tagged template is replaced");
+    });
+
+    it("warns when more than one argument is passed", function() {
+      assert.throws(function() {
+        transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs('first', 'second');");
+      }, /hbs should be invoked with a single argument: the template string/);
+    });
+
+    it("warns when argument is not a string", function() {
+      assert.throws(function() {
+        transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs(123);");
+      }, /hbs should be invoked with a single argument: the template string/);
+    });
+
+    it("warns when no argument is passed", function() {
+      assert.throws(function() {
+        transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs();");
+      }, /hbs should be invoked with a single argument: the template string/);
+    });
+  });
 });


### PR DESCRIPTION
This addresses issue pangratz/ember-cli-htmlbars-inline-precompile#17 where this plugin couldn't be used with Coffeescript since the backtick is used to write normal JS code.