### PR TITLE
Port plugin to Babel 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,75 +2,66 @@ module.exports = function(precompile) {
   return function(babel) {
     var t = babel.types;
 
-    var replaceNodeWithPrecompiledTemplate = function(node, template) {
+    var replaceNodeWithPrecompiledTemplate = function(path, template) {
       var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template) + ")";
 
-      // Prefer calling replaceWithSourceString if it is present.
-      // this prevents a deprecation warning in Babel 5.6.7+.
-      //
-      // TODO: delete the fallback once we only support babel >= 5.6.7.
-      if (node.replaceWithSourceString) {
-        node.replaceWithSourceString(compiledTemplateString);
-      } else {
-        return compiledTemplateString;
-      }
-    }
+      path.replaceWithSourceString(compiledTemplateString);
+    };
 
+    return {
+      visitor: {
+        ImportDeclaration: function(path, state) {
+          var node = path.node
+          var file = state.file;
+          if (t.isLiteral(node.source, { value: "htmlbars-inline-precompile" })) {
+            var first = node.specifiers && node.specifiers[0];
+            if (t.isImportDefaultSpecifier(first)) {
+              file.importSpecifier = first.local.name;
+            } else {
+              var input = file.code;
+              var usedImportStatement = input.slice(node.start, node.end);
+              var msg = "Only `import hbs from 'htmlbars-inline-precompile'` is supported. You used: `" + usedImportStatement + "`";
+              throw path.buildCodeFrameError(msg);
+            }
 
-    return new babel.Transformer('htmlbars-inline-precompile', {
-      ImportDeclaration: function(node, parent, scope, file) {
-        if (t.isLiteral(node.source, { value: "htmlbars-inline-precompile" })) {
-          var first = node.specifiers && node.specifiers[0];
-          if (t.isImportDefaultSpecifier(first)) {
-            file.importSpecifier = first.local.name;
-          } else {
-            var input = file.code;
-            var usedImportStatement = input.slice(node.start, node.end);
-            var msg = "Only `import hbs from 'htmlbars-inline-precompile'` is supported. You used: `" + usedImportStatement + "`";
-            throw file.errorWithNode(node, msg);
+            path.remove();
           }
+        },
 
-          // Prefer calling dangerouslyRemove instead of remove (if present) to
-          // suppress a deprecation warning.
-          //
-          // TODO: delete the fallback once we only support babel >= 5.5.0.
-          if (typeof this.dangerouslyRemove === 'function') {
-            this.dangerouslyRemove();
-          } else {
-            this.remove();
+        CallExpression: function(path, state) {
+          var node = path.node
+          var file = state.file;
+          if (t.isIdentifier(node.callee, { name: file.importSpecifier })) {
+            var argumentErrorMsg = "hbs should be invoked with a single argument: the template string";
+            if (node.arguments.length !== 1) {
+              throw path.buildCodeFrameError(argumentErrorMsg);
+            }
+
+            var template = node.arguments[0].value;
+            if (typeof template !== "string") {
+              throw path.buildCodeFrameError(argumentErrorMsg);
+            }
+
+            return replaceNodeWithPrecompiledTemplate(path, template);
           }
-        }
-      },
+        },
 
-      CallExpression: function(node, parent, scope, file) {
-        if (t.isIdentifier(node.callee, { name: file.importSpecifier })) {
-          var argumentErrorMsg = "hbs should be invoked with a single argument: the template string";
-          if (node.arguments.length !== 1) {
-            throw file.errorWithNode(node, argumentErrorMsg);
+        TaggedTemplateExpression: function(path, state) {
+          var node = path.node
+          var file = state.file;
+          if (t.isIdentifier(node.tag, { name: file.importSpecifier })) {
+            if (node.quasi.expressions.length) {
+              throw path.buildCodeFrameError("placeholders inside a tagged template string are not supported");
+            }
+
+            var template = node.quasi.quasis.map(function(quasi) {
+              return quasi.value.cooked;
+            }).join("");
+
+            return replaceNodeWithPrecompiledTemplate(path, template);
           }
-
-          var template = node.arguments[0].value;
-          if (typeof template !== "string") {
-            throw file.errorWithNode(node, argumentErrorMsg);
-          }
-
-          return replaceNodeWithPrecompiledTemplate(this, template);
-        }
-      },
-
-      TaggedTemplateExpression: function(node, parent, scope, file) {
-        if (t.isIdentifier(node.tag, { name: file.importSpecifier })) {
-          if (node.quasi.expressions.length) {
-            throw file.errorWithNode(node, "placeholders inside a tagged template string are not supported");
-          }
-
-          var template = node.quasi.quasis.map(function(quasi) {
-            return quasi.value.cooked;
-          }).join("");
-
-          return replaceNodeWithPrecompiledTemplate(this, template);
         }
       }
-    });
+    };
   }
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Clemens Müller <cmueller.418@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^5.2.10",
+    "babel-core": "^6.7.4",
     "mocha": "^2.2.4"
   }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -9,7 +9,6 @@ describe("htmlbars-inline-precompile", function() {
   beforeEach(function() {
     transform = function(code, precompile) {
       return babel.transform(code, {
-        blacklist: ['strict', 'es6.modules'],
         plugins: [HTMLBarsInlinePrecompile(precompile)]
       }).code;
     }
@@ -42,9 +41,7 @@ describe("htmlbars-inline-precompile", function() {
   });
 
   it("doesn't replace unrelated tagged template strings", function() {
-    var expected = babel.transform("var compiled = anotherTag`hello`;", {
-      blacklist: ['strict']
-    }).code;
+    var expected = babel.transform("var compiled = anotherTag`hello`;").code;
 
     var transformed = transform('import hbs from "htmlbars-inline-precompile"; var compiled = anotherTag`hello`;', function(template) {
       return "precompiled(" + template + ")";


### PR DESCRIPTION
This won't be backwards compatible with Babel 5, so this should only be merged once ember-cli uses Babel 6 too.

This depends on [babel/broccoli-babel-transpiler](https://github.com/babel/broccoli-babel-transpiler) and [emberjs/emberjs-build](https://github.com/emberjs/emberjs-build) being Babel 6 compatible too.