### PR TITLE
Cleanup & referencesImport()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,6 @@
 module.exports = function(babel) {
   var t = babel.types;
 
-  var replaceNodeWithPrecompiledTemplate = function(precompile, path, template) {
-    var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template) + ")";
-
-    path.replaceWithSourceString(compiledTemplateString);
-  };
-
   return {
     visitor: {
       ImportDeclaration: function(path, state) {
@@ -60,3 +54,9 @@ module.exports = function(babel) {
     }
   };
 };
+
+function replaceNodeWithPrecompiledTemplate(precompile, path, template) {
+  var compiledTemplateString = "Ember.HTMLBars.template(" + precompile(template) + ")";
+
+  path.replaceWithSourceString(compiledTemplateString);
+}

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function(babel) {
   return {
     visitor: {
       ImportDeclaration: function(path, state) {
-        var node = path.node
+        var node = path.node;
         var file = state.file;
         if (t.isLiteral(node.source, { value: "htmlbars-inline-precompile" })) {
           var first = node.specifiers && node.specifiers[0];
@@ -28,7 +28,7 @@ module.exports = function(babel) {
       },
 
       CallExpression: function(path, state) {
-        var node = path.node
+        var node = path.node;
         var file = state.file;
         if (t.isIdentifier(node.callee, { name: file.importSpecifier })) {
           var argumentErrorMsg = "hbs should be invoked with a single argument: the template string";
@@ -46,7 +46,7 @@ module.exports = function(babel) {
       },
 
       TaggedTemplateExpression: function(path, state) {
-        var node = path.node
+        var node = path.node;
         var file = state.file;
         if (t.isIdentifier(node.tag, { name: file.importSpecifier })) {
           if (node.quasi.expressions.length) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,17 @@ module.exports = function(babel) {
 
   return {
     visitor: {
+      Program: {
+        enter: function(path, state) {
+          state.hbsImports = [];
+        },
+        exit: function(path, state) {
+          state.hbsImports.forEach(function(path) {
+            path.remove();
+          });
+        },
+      },
+
       ImportDeclaration: function(path, state) {
         var node = path.node;
         if (t.isLiteral(node.source, { value: "htmlbars-inline-precompile" })) {
@@ -16,7 +27,7 @@ module.exports = function(babel) {
             throw path.buildCodeFrameError(msg);
           }
 
-          path.remove();
+          state.hbsImports.push(path);
         }
       },
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -39,13 +39,11 @@ describe("htmlbars-inline-precompile", function() {
   });
 
   it("doesn't replace unrelated tagged template strings", function() {
-    var expected = babel.transform("var compiled = anotherTag`hello`;").code;
-
     var transformed = transform('import hbs from "htmlbars-inline-precompile";\nvar compiled = anotherTag`hello`;', function(template) {
       return "precompiled(" + template + ")";
     });
 
-    assert.equal(transformed, expected, "other tagged template strings are not touched");
+    assert.equal(transformed, "var compiled = anotherTag`hello`;", "other tagged template strings are not touched");
   });
 
   it("warns when the tagged template string contains placeholders", function() {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -8,12 +8,12 @@ function transform(code, precompile) {
     plugins: [
       [HTMLBarsInlinePrecompile, {precompile: precompile}],
     ],
-  }).code;
+  }).code.trim();
 }
 
 describe("htmlbars-inline-precompile", function() {
   it("strips import statement for 'htmlbars-inline-precompile' module", function() {
-    var transformed = transform("import hbs from 'htmlbars-inline-precompile'; import Ember from 'ember';");
+    var transformed = transform("import hbs from 'htmlbars-inline-precompile';\nimport Ember from 'ember';");
 
     assert.equal(transformed, "import Ember from 'ember';", "strips import statement");
   });
@@ -31,7 +31,7 @@ describe("htmlbars-inline-precompile", function() {
 
 
   it("replaces tagged template expressions with precompiled version", function() {
-    var transformed = transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs`hello`;", function(template) {
+    var transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`hello`;", function(template) {
       return "precompiled(" + template + ")";
     });
 
@@ -41,7 +41,7 @@ describe("htmlbars-inline-precompile", function() {
   it("doesn't replace unrelated tagged template strings", function() {
     var expected = babel.transform("var compiled = anotherTag`hello`;").code;
 
-    var transformed = transform('import hbs from "htmlbars-inline-precompile"; var compiled = anotherTag`hello`;', function(template) {
+    var transformed = transform('import hbs from "htmlbars-inline-precompile";\nvar compiled = anotherTag`hello`;', function(template) {
       return "precompiled(" + template + ")";
     });
 
@@ -50,13 +50,13 @@ describe("htmlbars-inline-precompile", function() {
 
   it("warns when the tagged template string contains placeholders", function() {
     assert.throws(function() {
-      transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs`string ${value}`");
+      transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs`string ${value}`");
     }, /placeholders inside a tagged template string are not supported/);
   });
 
   describe('single string argument', function() {
     it("works with a plain string as parameter hbs('string')", function() {
-      var transformed = transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs('hello');", function(template) {
+      var transformed = transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('hello');", function(template) {
         return "precompiled(" + template + ")";
       });
 
@@ -65,19 +65,19 @@ describe("htmlbars-inline-precompile", function() {
 
     it("warns when more than one argument is passed", function() {
       assert.throws(function() {
-        transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs('first', 'second');");
+        transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs('first', 'second');");
       }, /hbs should be invoked with a single argument: the template string/);
     });
 
     it("warns when argument is not a string", function() {
       assert.throws(function() {
-        transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs(123);");
+        transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs(123);");
       }, /hbs should be invoked with a single argument: the template string/);
     });
 
     it("warns when no argument is passed", function() {
       assert.throws(function() {
-        transform("import hbs from 'htmlbars-inline-precompile'; var compiled = hbs();");
+        transform("import hbs from 'htmlbars-inline-precompile';\nvar compiled = hbs();");
       }, /hbs should be invoked with a single argument: the template string/);
     });
   });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,19 +3,15 @@ var assert = require('assert');
 var babel = require('babel-core');
 var HTMLBarsInlinePrecompile = require('../index');
 
-var transform;
+function transform(code, precompile) {
+  return babel.transform(code, {
+    plugins: [
+      [HTMLBarsInlinePrecompile, {precompile: precompile}],
+    ],
+  }).code;
+}
 
 describe("htmlbars-inline-precompile", function() {
-  beforeEach(function() {
-    transform = function(code, precompile) {
-      return babel.transform(code, {
-        plugins: [
-          [HTMLBarsInlinePrecompile, {precompile: precompile}],
-        ],
-      }).code;
-    }
-  });
-
   it("strips import statement for 'htmlbars-inline-precompile' module", function() {
     var transformed = transform("import hbs from 'htmlbars-inline-precompile'; import Ember from 'ember';");
 


### PR DESCRIPTION
This PR cleans up the code base a little bit and resolves #3 by using the `referencesImport()` method to figure out if a node should be replaced.

/cc @pangratz @stefanpenner